### PR TITLE
Fix: Update imports to use custom hooks instead of context exports

### DIFF
--- a/src/components/cart/Cart.jsx
+++ b/src/components/cart/Cart.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useCart } from '../../context/CartContext'
+import { useCart } from '../../hooks/useCart'
 import { useTenant } from '../../hooks/useTenant'
 import { X, Plus, Minus, ShoppingCart, Trash2, MessageSquare, CheckCircle, Clock } from 'lucide-react'
 

--- a/src/components/cart/FloatingCartButton.jsx
+++ b/src/components/cart/FloatingCartButton.jsx
@@ -1,4 +1,4 @@
-import { useCart } from "../../context/CartContext";
+import { useCart } from "../../hooks/useCart";
 import { useTenant } from '../../hooks/useTenant';
 import { ShoppingCart } from "lucide-react";
 import { getOptimalTextClass } from "../../utils/helpers";

--- a/src/components/menu/MenuCard.jsx
+++ b/src/components/menu/MenuCard.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Plus, Minus, Clock, Thermometer } from 'lucide-react'
 import { useTenant } from '../../hooks/useTenant'
-import { useCart } from '../../context/CartContext'
+import { useCart } from '../../hooks/useCart'
 import { getOptimalTextClass } from '../../utils/helpers'
 
 const MenuCard = ({ product }) => {

--- a/src/test/context/CartContext.test.jsx
+++ b/src/test/context/CartContext.test.jsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { CartProvider, useCart } from '../../context/CartContext'
+import { CartProvider } from '../../context/CartContext'
+import { useCart } from '../../hooks/useCart'
 import { TenantProvider } from '../../context/TenantContext'
 import { mockTenant, mockProduct, resetAllMocks, createMockSupabase } from '../utils'
 

--- a/src/test/context/TenantContext.test.jsx
+++ b/src/test/context/TenantContext.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor, act } from '@testing-library/react'
-import { TenantProvider, useTenant } from '../../context/TenantContext'
+import { TenantProvider } from '../../context/TenantContext'
+import { useTenant } from '../../hooks/useTenant'
 import { useIsTenant, useTenantUrl } from '../../hooks/useTenantHooks'
 import { createMockSupabase, mockTenant, mockTable, mockTableSession, mockLocation, resetAllMocks } from '../utils'
 


### PR DESCRIPTION
- Update Cart.jsx, FloatingCartButton.jsx, MenuCard.jsx to import useCart from hooks
- Update test files to import hooks from correct locations
- Resolves build error: "useCart is not exported by CartContext.jsx"
- Build now passes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)