### PR TITLE
Fix: Distinguish between global admin and tenant admin routes

### DIFF
--- a/src/context/TenantContext.jsx
+++ b/src/context/TenantContext.jsx
@@ -100,17 +100,21 @@ const getAppType = () => {
   const subdomain = getSubdomain()
   const tableCode = getTableCode()
 
-  // Admin específico - mejorada detección para local y producción
-  if (hostname.startsWith('admin.') ||
-      pathname.startsWith('/admin') ||
-      (hostname === 'localhost' && pathname.includes('/admin')) ||
-      (hostname.includes('local') && pathname.includes('/admin'))) {
-    return 'admin'
-  }
-
   // Si hay código de mesa, es una sesión de mesa
   if (subdomain && tableCode) {
     return 'table'
+  }
+
+  // Admin: diferenciar entre super admin global y admin de tenant
+  // Super Admin Global: tappmesa.vercel.app/admin, admin.tappmesa.com, localhost/admin SIN subdomain
+  if (pathname.startsWith('/admin') || hostname.startsWith('admin.')) {
+    // Si NO hay subdomain, es super admin global
+    if (!subdomain) {
+      return 'admin'
+    }
+    // Si HAY subdomain (ej: teteria-luna.tappmesa.vercel.app/admin)
+    // es el admin específico de ese tenant
+    return 'tenant'
   }
 
   // Si hay subdominio, es una cafetería


### PR DESCRIPTION
- Update getAppType() to differentiate admin types based on subdomain
- Global admin: tappmesa.vercel.app/admin (no subdomain)
- Tenant admin: teteria-luna.tappmesa.vercel.app/admin (with subdomain)
- Fixes issue where tenant subdomain + /admin was not loading tenant data
- Now teteria-luna.tappmesa.vercel.app/admin correctly loads Tetería Luna context

🤖 Generated with [Claude Code](https://claude.com/claude-code)