### PR TITLE
Feature: Support manual Vercel subdomain configuration

### DIFF
--- a/src/context/TenantContext.jsx
+++ b/src/context/TenantContext.jsx
@@ -51,15 +51,31 @@ const getSubdomain = () => {
     return null
   }
 
-  // Producción con Vercel: teteria-luna.tappmesa.vercel.app
+  // Producción con Vercel: teteria-luna-tappmesa.vercel.app
   if (hostname.includes('tappmesa.vercel.app')) {
+    // Nueva lógica para manejar formato: [nombre]-tappmesa.vercel.app
+    if (parts.length >= 3) {
+      const fullSubdomain = parts[0] // ej: "teteria-luna-tappmesa"
+
+      // Verificar si termina con -tappmesa (nuevo formato)
+      if (fullSubdomain.includes('-tappmesa')) {
+        // Usar el nombre completo incluyendo -tappmesa para matching con DB
+        if (!['www-tappmesa', 'admin-tappmesa', 'api-tappmesa', 'app-tappmesa'].includes(fullSubdomain)) {
+          console.log('🚀 Vercel subdomain detected (new format):', fullSubdomain)
+          return fullSubdomain
+        }
+      }
+    }
+
+    // Formato legacy: teteria-luna.tappmesa.vercel.app (por compatibilidad)
     if (parts.length >= 4) {
       const subdomain = parts[0]
       if (!['www', 'admin', 'api', 'app'].includes(subdomain)) {
-        console.log('🚀 Vercel subdomain detected:', subdomain)
+        console.log('🚀 Vercel subdomain detected (legacy format):', subdomain)
         return subdomain
       }
     }
+
     return null
   }
 


### PR DESCRIPTION
- Add detection for new subdomain format: [name]-tappmesa.vercel.app
- Support both new format (teteria-luna-tappmesa) and legacy format
- Enable manual subdomain configuration without wildcard domains
- Maintain backward compatibility with existing subdomain detection
- Add detailed logging for both subdomain formats

New subdomain pattern:
- teteria-luna-tappmesa.vercel.app → detects 'teteria-luna-tappmesa'
- cafe-central-tappmesa.vercel.app → detects 'cafe-central-tappmesa'
- bistro-sunrise-tappmesa.vercel.app → detects 'bistro-sunrise-tappmesa'

This enables multi-tenant subdomains on Vercel without requiring a custom domain or wildcard DNS configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)