### PR TITLE
fix: Correct column name from is_active to is_available

### DIFF
--- a/src/pages/waiter/components/CreateOrderModal.jsx
+++ b/src/pages/waiter/components/CreateOrderModal.jsx
@@ -32,7 +32,7 @@ const CreateOrderModal = ({ tenant, tables, selectedTable, onClose, onSuccess })
         .from('products')
         .select('*')
         .eq('tenant_id', tenant.id)
-        .eq('is_active', true)
+        .eq('is_available', true)
         .order('name')
 
       if (error) {


### PR DESCRIPTION
Fixed 400 error when loading products in waiter dashboard.

Problem:
- Code was filtering by 'is_active' column
- Database has 'is_available' column instead
- This caused 400 error: 'column products.is_active does not exist'

Solution:
- Changed .eq('is_active', true) to .eq('is_available', true)
- Now matches the actual schema in prisma/schema.prisma

Products should now load correctly in waiter dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)