### PR TITLE
fix: Remove non-existent order_type column from orders insert

### DIFF
--- a/src/pages/waiter/components/CreateOrderModal.jsx
+++ b/src/pages/waiter/components/CreateOrderModal.jsx
@@ -179,8 +179,7 @@ const CreateOrderModal = ({ tenant, tables, selectedTable, onClose, onSuccess })
           subtotal,
           tax,
           total,
-          status: 'pending',
-          order_type: 'dine-in'
+          status: 'pending'
         })
         .select()
         .single()


### PR DESCRIPTION
Fixed 400 error when creating orders in waiter dashboard.

Problem:
- Code was trying to insert 'order_type' column
- Database schema doesn't have this column
- Error: "Could not find the 'order_type' column of 'orders'"

Solution:
- Removed order_type: 'dine-in' from insert statement
- Orders table schema only has: tenant_id, table_session_id, order_number, subtotal, tax, total, status, etc.

Orders should now be created successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)