### PR TITLE
Fix: Update CSP to allow Vercel services scripts

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -33,7 +33,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.supabase.co wss://*.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://*.vercel.app https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vercel.live https://*.vercel.app https://vitals.vercel-insights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
         }
       ]
     },


### PR DESCRIPTION
## Summary
Updates Content Security Policy headers to allow Vercel's built-in services and tooling, resolving CSP violations in production.

### Issue
Vercel deployment was showing CSP errors in the console:
```
Refused to load the script 'https://vercel.live/_next-live/feedback/feedback.js' 
because it violates the following Content Security Policy directive: 
"script-src 'self' 'unsafe-inline' 'unsafe-eval'"
```

### Changes Made
Updated `vercel.json` CSP headers to whitelist Vercel service domains:

**script-src additions:**
- `https://vercel.live` - Vercel Live Feedback/collaboration tools
- `https://*.vercel.app` - Vercel app scripts
- `https://va.vercel-scripts.com` - Vercel Analytics scripts

**connect-src additions:**
- `https://vercel.live` - Live Feedback connections
- `https://*.vercel.app` - Vercel service connections
- `https://vitals.vercel-insights.com` - Vercel Analytics/Web Vitals

### Security Note
These domains are all official Vercel services required for:
- Live collaboration and feedback tools
- Analytics and performance monitoring
- Deployment insights

All domains are HTTPS-only and controlled by Vercel.

### Test Plan
- [x] Verify CSP syntax is correct
- [ ] Deploy to Vercel and check browser console for CSP errors
- [ ] Verify Vercel Analytics loads correctly
- [ ] Verify Vercel Live Feedback is accessible (if enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)