### PR TITLE
fix: Add frame-src to CSP for Vercel Live iframes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -33,7 +33,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://*.vercel.app https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vercel.live https://*.vercel.app https://vitals.vercel-insights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://*.vercel.app https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vercel.live https://*.vercel.app https://vitals.vercel-insights.com; frame-src https://vercel.live https://*.vercel.app; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
         }
       ]
     },


### PR DESCRIPTION
Add frame-src directive to Content Security Policy to allow Vercel Live collaboration tool to load its iframes.

Without frame-src, the policy falls back to default-src 'self' which blocks all external iframes including Vercel Live.

Added domains:
- https://vercel.live
- https://*.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)