### PR TITLE
fix: Update CSP to allow Vercel services scripts

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -33,7 +33,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.supabase.co wss://*.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://*.vercel.app https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vercel.live https://*.vercel.app https://vitals.vercel-insights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
         }
       ]
     },


### PR DESCRIPTION
Add Vercel domains to Content Security Policy to allow:
- Vercel Live Feedback scripts (vercel.live)
- Vercel Analytics (va.vercel-scripts.com, vitals.vercel-insights.com)
- Other Vercel app scripts (*.vercel.app)

This resolves CSP violations preventing Vercel tooling from loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)