### PR TITLE
perf(bundle): fix lazy loading and remove unused prisma dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
-    "@prisma/client": "6.4.1",
     "@radix-ui/themes": "^3.2.1",
     "@sentry/react": "^10.17.0",
     "@sentry/vite-plugin": "^5.1.1",
@@ -63,6 +62,7 @@
     "globals": "^17.4.0",
     "jsdom": "^29.0.1",
     "postcss": "^8.5.10",
+    "@prisma/client": "6.4.1",
     "prisma": "6.4.1",
     "tailwindcss": "^4.2.2",
     "vite": "^8.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,9 +16,6 @@ importers:
 
   .:
     dependencies:
-      '@prisma/client':
-        specifier: 6.4.1
-        version: 6.4.1(prisma@6.4.1)
       '@radix-ui/themes':
         specifier: ^3.2.1
         version: 3.3.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -77,6 +74,9 @@ importers:
       '@flydotio/dockerfile':
         specifier: ^0.7.10
         version: 0.7.10(@types/node@25.6.0)
+      '@prisma/client':
+        specifier: 6.4.1
+        version: 6.4.1(prisma@6.4.1)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,14 +19,12 @@ import {
   PrivacyPage,
   TermsPage,
   HelpPage,
-  ContactPage
+  ContactPage,
+  ReservationsPage,
+  WaiterDashboard,
+  KitchenDashboard,
+  ContactSales
 } from './components/LazyComponents';
-
-// Importar directamente (no lazy) para reservas y waiter
-import ReservationsPage from './pages/reservations/ReservationsPage';
-import WaiterDashboard from './pages/waiter/WaiterDashboard';
-import KitchenDashboard from './pages/kitchen/KitchenDashboard';
-import ContactSales from './pages/contact-sales/ContactSales';
 
 // Keep ProtectedRoute as regular import since it's lightweight
 import ProtectedRoute from './components/ProtectedRoute';

--- a/src/components/LazyComponents.jsx
+++ b/src/components/LazyComponents.jsx
@@ -28,6 +28,11 @@ const LazyTermsPage = lazy(() => import('../pages/landing/TermsPage'));
 const LazyHelpPage = lazy(() => import('../pages/landing/HelpPage'));
 const LazyContactPage = lazy(() => import('../pages/landing/ContactPage'));
 
+// Lazy load secondary page components (not in the critical path)
+const LazyWaiterDashboard = lazy(() => import('../pages/waiter/WaiterDashboard'));
+const LazyKitchenDashboard = lazy(() => import('../pages/kitchen/KitchenDashboard'));
+const LazyContactSales = lazy(() => import('../pages/contact-sales/ContactSales'));
+
 // Lazy load layout components
 const LazyMenuLayout = lazy(() => import('./layout/MenuLayout'));
 
@@ -58,6 +63,10 @@ export const HelpPage = withSuspense(LazyHelpPage, "Cargando ayuda...");
 export const ContactPage = withSuspense(LazyContactPage, "Cargando contacto...");
 
 export const MenuLayout = withSuspense(LazyMenuLayout, "Cargando menú...");
+
+export const WaiterDashboard = withSuspense(LazyWaiterDashboard, "Cargando panel del garzón...");
+export const KitchenDashboard = withSuspense(LazyKitchenDashboard, "Cargando panel de cocina...");
+export const ContactSales = withSuspense(LazyContactSales, "Cargando...");
 
 // Also export the LoadingSpinner for direct use
 export { LoadingSpinner };


### PR DESCRIPTION
## Summary

- Convierte imports estáticos de páginas secundarias a lazy loading real
- Elimina import duplicado de `ReservationsPage` que rompía el code splitting
- Mueve `@prisma/client` a devDependencies (código muerto en el frontend)

## Bundle Impact

| Métrica | Antes | Después | Mejora |
|---------|-------|---------|--------|
| index.js (raw) | 66 kB | 8 kB | -88% |
| index.js (gzip) | 13.8 kB | 2.5 kB | -82% |
| Advertencias build | INEFFECTIVE_DYNAMIC_IMPORT | 0 | ✅ |

## Chunks creados

| Chunk | Tamaño |
|-------|--------|
| `ReservationsPage` | 4.1 kB (1.2 kB gzip) |
| `WaiterDashboard` | 25.7 kB (5.8 kB gzip) |
| `KitchenDashboard` | 9.3 kB (2.8 kB gzip) |
| `ContactSales` | 10.8 kB (2.9 kB gzip) |
| `ReservationForm` | 10.0 kB (2.6 kB gzip) |

## Files Changed

| File | Change |
|------|--------|
| `src/App.jsx` | Static → lazy imports for 4 pages |
| `src/components/LazyComponents.jsx` | Added 3 new lazy exports |
| `package.json` | @prisma/client → devDependencies |

## Test Plan

- [x] Build passes with zero warnings
- [x] 50 existing tests pass
- [x] Lazy chunks appear as separate files in dist/

## Checklist

- Conventional commit format
- No Co-Authored-By trailers
- Bundle analyzed before/after