### PR TITLE
fix(auth): add missing tenant_id filters to prevent cross-tenant data access

### DIFF
--- a/openspec/changes/archive/2026-06-10-fix-supabase-critical-filters/proposal.md
+++ b/openspec/changes/archive/2026-06-10-fix-supabase-critical-filters/proposal.md
@@ -1,0 +1,70 @@
+# Proposal: fix-supabase-critical-filters
+
+## Intent
+
+Multi-tenant SaaS without Supabase Auth (custom bcrypt auth) means RLS policies can't use `auth.uid()` for tenant isolation. Five direct Supabase mutations lack `tenant_id` filters, allowing cross-tenant writes. One debug query leaks all tenant names. One broken import crashes reservations.
+
+## Scope
+
+### In Scope
+1. **KitchenDashboard.updateOrderStatus** — add `.eq('tenant_id', tenant.id)` to local supabase call
+2. **customerService.getCustomerHistory** — add `tenantId` param + `.eq('tenant_id', tenantId)`
+3. **TenantContext debug query** — remove the "show all tenants" fallback query
+4. **CompleteStockManager.handleEdit** — add `.eq('tenant_id', currentTenant.id)` to stock_inventory.update
+5. **CompleteStockManager.resolveAlert** — add `.eq('tenant_id', currentTenant.id)` to stock_alerts.update
+6. **supabase.js reservationService** — export `reservationService` with `getTableAvailability`, `createReservation`, `getReservations` methods
+
+### Out of Scope
+- OrdersManager.jsx — already has `.eq('tenant_id', tenantId)` ✓
+- RLS policy rewrites — auth model unchanged
+- Tests for reservationService (stub only)
+
+## Capabilities
+
+### New Capabilities
+- `stock-management`: Adds tenant-scoped writes to inventory/alerts
+- `customer-history`: Adds tenant-scoped customer history queries
+- `reservations-management`: Provides the reservation service stub
+
+### Modified Capabilities
+- None — this is a security/hygiene patch, no spec-level behavior change
+
+## Approach
+
+Each fix is an isolated 1-3 line change: add `.eq('tenant_id', ...)` filter or (for debug query) remove the offending block. `reservationService` gets a minimal export in `supabase.js` implementing the 3 methods ReservationsContext expects.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `src/pages/kitchen/KitchenDashboard.jsx:92-109` | Modified | Add tenant filter to local updateOrderStatus |
+| `src/lib/supabase.js:558-581` | Modified | Add tenantId param + filter to getCustomerHistory |
+| `src/lib/supabase.js:end` | Modified | Add reservationService export |
+| `src/context/TenantContext.jsx:256-261` | Removed | Delete debug query |
+| `src/components/admin/CompleteStockManager.jsx:233-247` | Modified | Add tenant filter to handleEdit |
+| `src/components/admin/CompleteStockManager.jsx:297-300` | Modified | Add tenant filter to resolveAlert |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| getCustomerHistory callers break (new param) | Low | All callers pass tenantId already; verify after fix |
+| reservationService stub missing edge methods | Low | Only 3 methods used in ReservationsContext; doc what's missing |
+| KitchenDashboard order update silently fails | Low | `select()` or check error; mutation scoped correctly |
+
+## Rollback Plan
+
+Revert the commit per file. Each change is independent — can revert one without affecting others. Test KitchenDashboard order status flow after rollback.
+
+## Dependencies
+
+None.
+
+## Success Criteria
+
+- [ ] KitchenDashboard updates order status scoped to current tenant
+- [ ] getCustomerHistory filters by tenant_id
+- [ ] TenantContext no longer queries all tenants on subdomain failure
+- [ ] CompleteStockManager edits and alert resolutions scoped to current tenant
+- [ ] ReservationsContext loads without import error
+- [ ] All existing tests pass

--- a/openspec/changes/archive/2026-06-10-fix-supabase-critical-filters/spec.md
+++ b/openspec/changes/archive/2026-06-10-fix-supabase-critical-filters/spec.md
@@ -1,0 +1,130 @@
+# Delta Spec: fix-supabase-critical-filters
+
+## Purpose
+
+Multi-tenant SaaS with custom bcrypt auth cannot rely on `auth.uid()` in RLS, so application-level `tenant_id` filters MUST be explicit. This spec covers 6 independent fixes: adding missing `tenant_id` filters to 5 Supabase mutations and removing one data-leaking debug query.
+
+## ADDED Requirements
+
+### R1: KitchenDashboard.updateOrderStatus MUST scope by tenant_id
+
+The `updateOrderStatus` function in KitchenDashboard SHALL add `.eq('tenant_id', tenant.id)` to the Supabase update call, using the `tenant` prop already received by the component.
+
+#### Scenario: Order update scoped to current tenant
+
+- GIVEN a kitchen user with `tenant.id = "A"`
+- WHEN they call `updateOrderStatus("order-1", "preparing")`
+- THEN the update SHALL include `.eq('tenant_id', "A")`
+- AND only orders belonging to tenant A SHALL be updated
+
+#### Scenario: Cross-tenant update hits zero rows
+
+- GIVEN a user of tenant A
+- WHEN they attempt to update an order belonging to tenant B
+- THEN the query SHALL return 0 matched rows
+- AND the catch block SHALL display an error
+
+### R2: getCustomerHistory MUST accept and filter by tenantId
+
+`customerService.getCustomerHistory` SHALL accept a `tenantId` second parameter and add `.eq('tenant_id', tenantId)` to the Supabase query.
+
+#### Scenario: History filtered by tenant
+
+- GIVEN a customer with entries in tenants A and B
+- WHEN an admin of tenant A calls `getCustomerHistory("cust-1", "A")`
+- THEN the query SHALL include `.eq('tenant_id', "A")`
+- AND only tenant A entries SHALL be returned
+
+#### Scenario: Cross-tenant data excluded
+
+- GIVEN the same query for tenant A
+- THEN entries belonging to tenant B SHALL NOT appear in results
+
+### R3: TenantContext MUST NOT dump all tenants on failure
+
+The debug fallback `supabase.from('tenants').select('subdomain, name').eq('is_active', true)` in the `loadTenant` catch block SHALL be removed entirely.
+
+#### Scenario: Unknown subdomain fails silently (no leak)
+
+- GIVEN a visitor accesses `nonexistent.localhost:5173`
+- WHEN `loadTenant` fails to resolve the subdomain
+- THEN the catch branch SHALL throw the error WITHOUT querying all tenants
+- AND no tenant list SHALL be logged or returned
+
+### R4: stock_inventory.update MUST scope by tenant_id
+
+`handleEdit` in CompleteStockManager SHALL add `.eq('tenant_id', currentTenant.id)` to the `stock_inventory.update()` call.
+
+#### Scenario: Inventory edit scoped to own tenant
+
+- GIVEN an admin with `currentTenant.id = "A"`
+- WHEN they edit a stock item via `handleEdit`
+- THEN the update SHALL include `.eq('tenant_id', "A")`
+- AND only items belonging to tenant A SHALL be updated
+
+#### Scenario: Cross-tenant edit blocked
+
+- GIVEN an admin of tenant A
+- WHEN they edit an item belonging to tenant B
+- THEN the update SHALL affect 0 rows
+
+### R5: stock_alerts.resolveAlert MUST scope by tenant_id
+
+`resolveAlert` in CompleteStockManager SHALL add `.eq('tenant_id', currentTenant.id)` to the `stock_alerts.update()` call.
+
+#### Scenario: Alert resolution scoped to own tenant
+
+- GIVEN an admin with `currentTenant.id = "A"`
+- WHEN they call `resolveAlert("alert-1")`
+- THEN the update SHALL include `.eq('tenant_id', "A")`
+- AND only alerts belonging to tenant A SHALL be resolved
+
+#### Scenario: Cross-tenant alert blocked
+
+- GIVEN an admin of tenant A
+- WHEN they attempt to resolve an alert belonging to tenant B
+- THEN the update SHALL affect 0 rows
+
+### R6: reservationService MUST be exported with three methods
+
+`src/lib/supabase.js` SHALL export `reservationService` providing `getTableAvailability`, `createReservation`, and `getReservations` matching the interface that `ReservationsContext` imports. Each method SHALL scope queries by `tenant_id`.
+
+#### Scenario: Import succeeds without error
+
+- GIVEN `ReservationsContext.jsx` imports `{ reservationService }` from `../../lib/supabase`
+- WHEN the app loads
+- THEN the import SHALL succeed
+- AND all three methods SHALL be callable functions
+
+#### Scenario: getTableAvailability returns tenant-scoped tables
+
+- GIVEN a call to `getTableAvailability(tenantId, date, time)`
+- WHEN the tenant has available tables
+- THEN it SHALL return `{ success: true, availableTables }`
+- AND the query SHALL filter by `.eq('tenant_id', tenantId)`
+
+#### Scenario: createReservation inserts with tenant_id
+
+- GIVEN `createReservation({ tenantId, customerName, date, time, ... })`
+- WHEN called with valid data
+- THEN it SHALL insert into `reservations` with `tenant_id`
+- AND return `{ success: true, reservation }`
+
+#### Scenario: getReservations returns tenant-scoped reservations
+
+- GIVEN `getReservations(tenantId, date)`
+- WHEN called with a valid tenantId
+- THEN it SHALL query `reservations` filtered by `tenant_id`
+- AND return `{ success: true, reservations }`
+
+---
+
+## Success Criteria
+
+- [ ] KitchenDashboard order status updates scoped to current tenant
+- [ ] getCustomerHistory filters by tenant_id
+- [ ] TenantContext no longer queries all tenants on subdomain failure
+- [ ] CompleteStockManager edits scoped to current tenant
+- [ ] CompleteStockManager alert resolutions scoped to current tenant
+- [ ] ReservationsContext loads without import error
+- [ ] All existing tests pass

--- a/openspec/specs/multi-tenant-isolation/spec.md
+++ b/openspec/specs/multi-tenant-isolation/spec.md
@@ -1,0 +1,132 @@
+# Spec: Multi-Tenant Data Isolation
+
+## Domain
+
+Multi-tenant data isolation — Supabase query-level tenant scoping for custom auth (no auth.uid()).
+
+## Purpose
+
+Multi-tenant SaaS with custom bcrypt auth cannot rely on `auth.uid()` in RLS, so application-level `tenant_id` filters MUST be explicit. This spec covers 6 independent fixes: adding missing `tenant_id` filters to 5 Supabase mutations and removing one data-leaking debug query.
+
+## Requirements
+
+### R1: KitchenDashboard.updateOrderStatus MUST scope by tenant_id
+
+The `updateOrderStatus` function in KitchenDashboard SHALL add `.eq('tenant_id', tenant.id)` to the Supabase update call, using the `tenant` prop already received by the component.
+
+#### Scenario: Order update scoped to current tenant
+
+- GIVEN a kitchen user with `tenant.id = "A"`
+- WHEN they call `updateOrderStatus("order-1", "preparing")`
+- THEN the update SHALL include `.eq('tenant_id', "A")`
+- AND only orders belonging to tenant A SHALL be updated
+
+#### Scenario: Cross-tenant update hits zero rows
+
+- GIVEN a user of tenant A
+- WHEN they attempt to update an order belonging to tenant B
+- THEN the query SHALL return 0 matched rows
+- AND the catch block SHALL display an error
+
+### R2: getCustomerHistory MUST accept and filter by tenantId
+
+`customerService.getCustomerHistory` SHALL accept a `tenantId` second parameter and add `.eq('tenant_id', tenantId)` to the Supabase query.
+
+#### Scenario: History filtered by tenant
+
+- GIVEN a customer with entries in tenants A and B
+- WHEN an admin of tenant A calls `getCustomerHistory("cust-1", "A")`
+- THEN the query SHALL include `.eq('tenant_id', "A")`
+- AND only tenant A entries SHALL be returned
+
+#### Scenario: Cross-tenant data excluded
+
+- GIVEN the same query for tenant A
+- THEN entries belonging to tenant B SHALL NOT appear in results
+
+### R3: TenantContext MUST NOT dump all tenants on failure
+
+The debug fallback `supabase.from('tenants').select('subdomain, name').eq('is_active', true)` in the `loadTenant` catch block SHALL be removed entirely.
+
+#### Scenario: Unknown subdomain fails silently (no leak)
+
+- GIVEN a visitor accesses `nonexistent.localhost:5173`
+- WHEN `loadTenant` fails to resolve the subdomain
+- THEN the catch branch SHALL throw the error WITHOUT querying all tenants
+- AND no tenant list SHALL be logged or returned
+
+### R4: stock_inventory.update MUST scope by tenant_id
+
+`handleEdit` in CompleteStockManager SHALL add `.eq('tenant_id', currentTenant.id)` to the `stock_inventory.update()` call.
+
+#### Scenario: Inventory edit scoped to own tenant
+
+- GIVEN an admin with `currentTenant.id = "A"`
+- WHEN they edit a stock item via `handleEdit`
+- THEN the update SHALL include `.eq('tenant_id', "A")`
+- AND only items belonging to tenant A SHALL be updated
+
+#### Scenario: Cross-tenant edit blocked
+
+- GIVEN an admin of tenant A
+- WHEN they edit an item belonging to tenant B
+- THEN the update SHALL affect 0 rows
+
+### R5: stock_alerts.resolveAlert MUST scope by tenant_id
+
+`resolveAlert` in CompleteStockManager SHALL add `.eq('tenant_id', currentTenant.id)` to the `stock_alerts.update()` call.
+
+#### Scenario: Alert resolution scoped to own tenant
+
+- GIVEN an admin with `currentTenant.id = "A"`
+- WHEN they call `resolveAlert("alert-1")`
+- THEN the update SHALL include `.eq('tenant_id', "A")`
+- AND only alerts belonging to tenant A SHALL be resolved
+
+#### Scenario: Cross-tenant alert blocked
+
+- GIVEN an admin of tenant A
+- WHEN they attempt to resolve an alert belonging to tenant B
+- THEN the update SHALL affect 0 rows
+
+### R6: reservationService MUST be exported with three methods
+
+`src/lib/supabase.js` SHALL export `reservationService` providing `getTableAvailability`, `createReservation`, and `getReservations` matching the interface that `ReservationsContext` imports. Each method SHALL scope queries by `tenant_id`.
+
+#### Scenario: Import succeeds without error
+
+- GIVEN `ReservationsContext.jsx` imports `{ reservationService }` from `../../lib/supabase`
+- WHEN the app loads
+- THEN the import SHALL succeed
+- AND all three methods SHALL be callable functions
+
+#### Scenario: getTableAvailability returns tenant-scoped tables
+
+- GIVEN a call to `getTableAvailability(tenantId, date, time)`
+- WHEN the tenant has available tables
+- THEN it SHALL return `{ success: true, availableTables }`
+- AND the query SHALL filter by `.eq('tenant_id', tenantId)`
+
+#### Scenario: createReservation inserts with tenant_id
+
+- GIVEN `createReservation({ tenantId, customerName, date, time, ... })`
+- WHEN called with valid data
+- THEN it SHALL insert into `reservations` with `tenant_id`
+- AND return `{ success: true, reservation }`
+
+#### Scenario: getReservations returns tenant-scoped reservations
+
+- GIVEN `getReservations(tenantId, date)`
+- WHEN called with a valid tenantId
+- THEN it SHALL query `reservations` filtered by `tenant_id`
+- AND return `{ success: true, reservations }`
+
+## Success Criteria
+
+- [ ] KitchenDashboard order status updates scoped to current tenant
+- [ ] getCustomerHistory filters by tenant_id
+- [ ] TenantContext no longer queries all tenants on subdomain failure
+- [ ] CompleteStockManager edits scoped to current tenant
+- [ ] CompleteStockManager alert resolutions scoped to current tenant
+- [ ] ReservationsContext loads without import error
+- [ ] All existing tests pass

--- a/src/components/admin/CompleteStockManager.jsx
+++ b/src/components/admin/CompleteStockManager.jsx
@@ -244,6 +244,7 @@ const CompleteStockManager = () => {
           notes: editForm.notes || null,
           last_updated: new Date().toISOString(),
         })
+        .eq("tenant_id", currentTenant.id)
         .eq("id", selectedItem.id);
 
       if (error) throw error;
@@ -297,6 +298,7 @@ const CompleteStockManager = () => {
       const { error } = await supabase
         .from("stock_alerts")
         .update({ is_resolved: true, resolved_at: new Date().toISOString() })
+        .eq("tenant_id", currentTenant.id)
         .eq("id", alertId);
 
       if (error) throw error;

--- a/src/context/TenantContext.jsx
+++ b/src/context/TenantContext.jsx
@@ -252,13 +252,6 @@ export const TenantProvider = ({ children }) => {
         logger.error('❌ Tenant query error:', tenantError)
         logger.error('❌ Subdomain searched:', subdomain)
 
-        // Intentar buscar sin el filtro de subdomain para debugging
-        const { data: allTenants } = await supabase
-          .from('tenants')
-          .select('subdomain, name')
-          .eq('is_active', true)
-
-        logger.dev('📋 Available tenants:', allTenants)
         throw new Error(`Cafetería "${subdomain}" no encontrada`)
       }
       

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -555,7 +555,7 @@ export const customerService = {
   },
 
   // Obtener historial de cliente
-  async getCustomerHistory(customerId) {
+  async getCustomerHistory(customerId, tenantId) {
     try {
       const { data, error } = await supabase
         .from('customer_order_history')
@@ -569,6 +569,7 @@ export const customerService = {
           )
         `)
         .eq('customer_id', customerId)
+        .eq('tenant_id', tenantId)
         .order('created_at', { ascending: false })
 
       if (error) throw error
@@ -596,6 +597,98 @@ export const notificationService = {
       return { success: true }
     } catch (error) {
       console.error('Send notification error:', error)
+      return { success: false, error: error.message }
+    }
+  }
+}
+
+// Servicio de reservas
+export const reservationService = {
+  // Obtener disponibilidad de mesas para una fecha y hora
+  async getTableAvailability(tenantId, date, time) {
+    try {
+      // Obtener todas las mesas activas del tenant
+      const { data: tables, error: tablesError } = await supabase
+        .from('tables')
+        .select('id, number, capacity')
+        .eq('tenant_id', tenantId)
+        .eq('is_active', true)
+
+      if (tablesError) throw tablesError
+
+      // Obtener reservas existentes para esa fecha/hora
+      const { data: reservations, error: reservationsError } = await supabase
+        .from('reservations')
+        .select('table_id')
+        .eq('tenant_id', tenantId)
+        .eq('date', date)
+        .eq('time', time)
+        .neq('status', 'cancelled')
+
+      if (reservationsError) throw reservationsError
+
+      const reservedTableIds = new Set(
+        (reservations || []).map(r => r.table_id)
+      )
+
+      const availableTables = (tables || []).filter(
+        t => !reservedTableIds.has(t.id)
+      )
+
+      return { success: true, tables: availableTables }
+    } catch (error) {
+      console.error('Get table availability error:', error)
+      return { success: false, error: error.message }
+    }
+  },
+
+  // Crear una reserva
+  async createReservation({ tenantId, customerName, date, time, ...data }) {
+    try {
+      const { data: reservation, error } = await supabase
+        .from('reservations')
+        .insert({
+          tenant_id: tenantId,
+          customer_name: customerName,
+          date,
+          time,
+          ...data,
+          status: 'confirmed',
+          created_at: new Date().toISOString()
+        })
+        .select()
+        .single()
+
+      if (error) throw error
+
+      return { success: true, reservation }
+    } catch (error) {
+      console.error('Create reservation error:', error)
+      return { success: false, error: error.message }
+    }
+  },
+
+  // Obtener reservas de un tenant para una fecha
+  async getReservations(tenantId, date) {
+    try {
+      const { data, error } = await supabase
+        .from('reservations')
+        .select(`
+          *,
+          table:tables (
+            number,
+            capacity
+          )
+        `)
+        .eq('tenant_id', tenantId)
+        .eq('date', date)
+        .order('time', { ascending: true })
+
+      if (error) throw error
+
+      return { success: true, reservations: data }
+    } catch (error) {
+      console.error('Get reservations error:', error)
       return { success: false, error: error.message }
     }
   }

--- a/src/pages/kitchen/KitchenDashboard.jsx
+++ b/src/pages/kitchen/KitchenDashboard.jsx
@@ -97,6 +97,7 @@ const KitchenDashboard = () => {
           status: newStatus,
           updated_at: new Date().toISOString()
         })
+        .eq('tenant_id', tenant.id)
         .eq('id', orderId)
 
       if (error) throw error


### PR DESCRIPTION
## Summary
6 fixes de seguridad multi-tenant. Como el sistema usa custom auth (no Supabase Auth), las RLS policies con auth.uid() no funcionan. Estos fixes agregan filtros `tenant_id` faltantes en queries directas a Supabase.

## Changes
| File | Fix |
|------|-----|
| `KitchenDashboard.jsx` | Scope order status update by tenant_id |
| `supabase.js - getCustomerHistory` | Add tenantId param + .eq filter |
| `supabase.js - reservationService` | New export with 3 tenant-scoped methods |
| `TenantContext.jsx` | Remove debug query that dumped ALL tenants |
| `CompleteStockManager.jsx` | Scope inventory + alerts updates by tenant_id |

## Test Plan
- [x] 62 tests pass (0 regresiones)
- [x] Build exitoso

## Security Impact
- **CRITICAL FIX**: updateOrderStatus ya no permite cambiar estado de ordenes de otros tenants
- **CRITICAL FIX**: getCustomerHistory ya no permite leer historial cross-tenant
- **CRITICAL FIX**: Eliminado endpoint que exponia el directorio completo de tenants
- **CRITICAL FIX**: inventory/alerts updates ya no permiten writes cross-tenant