### PR TITLE
fix(db): change global unique constraints to be scoped by tenant

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -705,7 +705,7 @@ model customer_order_history {
 model customers {
   id                       String                   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   tenant_id                String?                  @db.Uuid
-  phone                    String                   @unique @db.VarChar
+  phone                    String                   @db.VarChar
   name                     String?                  @db.VarChar
   email                    String?                  @db.VarChar
   total_orders             Int?                     @default(0)
@@ -724,7 +724,7 @@ model customers {
   tenants                  tenants?                 @relation(fields: [tenant_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@index([tenant_id], map: "idx_customers_tenant_active")
-  @@index([tenant_id, phone], map: "idx_customers_tenant_phone")
+  @@unique([tenant_id, phone])
   @@schema("public")
 }
 
@@ -1234,7 +1234,7 @@ model tables {
   number               String           @db.VarChar
   capacity             Int
   location             String?          @db.VarChar
-  unique_code          String?          @unique @db.VarChar
+  unique_code          String?          @db.VarChar
   qr_code_url          String?
   status               String?          @default("available") @db.VarChar
   is_active            Boolean?         @default(true)
@@ -1249,6 +1249,7 @@ model tables {
   tenants              tenants?         @relation(fields: [tenant_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@unique([tenant_id, number])
+  @@unique([tenant_id, unique_code])
   @@schema("public")
 }
 


### PR DESCRIPTION
## Summary
Corrige dos constraints `@unique` globales que impedian el correcto funcionamiento multi-tenant.

## Changes
| File | Change | Impact |
|------|--------|--------|
| `prisma/schema.prisma` | `tables.unique_code`: `@unique` → `@@unique([tenant_id, unique_code])` | Dos tenants ahora pueden tener el mismo codigo de mesa |
| `prisma/schema.prisma` | `customers.phone`: `@unique` → `@@unique([tenant_id, phone])` | El mismo cliente puede registrarse en distintos locales |

## Migration SQL Required
Una vez mergeado, ejecutar en la base de datos:
```sql
ALTER TABLE tables DROP CONSTRAINT tables_unique_code_key;
ALTER TABLE customers DROP CONSTRAINT customers_phone_key;
CREATE UNIQUE INDEX IF NOT EXISTS idx_tables_tenant_unique_code
  ON tables(tenant_id, unique_code) WHERE unique_code IS NOT NULL;
CREATE UNIQUE INDEX IF NOT EXISTS idx_customers_tenant_phone
  ON customers(tenant_id, phone);
```

## Test Plan
- [x] Schema syntax validado
- [x] Sin regresiones en 62 tests existentes
- [x] Build exitoso

## Note
El archivo `prisma.config.ts` tiene un error pre-existente con `prisma migrate` (incompatible con Prisma 6.4.1). La migracion SQL debe ejecutarse manualmente contra Supabase.