### PR TITLE
fix(auth): replace in-memory rate limiter with Vercel KV

### DIFF
--- a/api/auth/reset-password.js
+++ b/api/auth/reset-password.js
@@ -41,7 +41,7 @@ module.exports = async function handler(req, res) {
 async function handleResetRequest(req, res) {
   // Rate limiting para reset requests
   const rateLimit = rateLimiter('auth/reset-password/request');
-  if (rateLimit(req, res)) {
+  if (await rateLimit(req, res)) {
     return;
   }
 

--- a/api/auth/signin.js
+++ b/api/auth/signin.js
@@ -27,7 +27,7 @@ module.exports = async function handler(req, res) {
 
   // Rate limiting
   const rateLimit = rateLimiter('auth/signin');
-  if (rateLimit(req, res)) {
+  if (await rateLimit(req, res)) {
     return; // Rate limit exceeded
   }
 

--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -40,7 +40,7 @@ module.exports = async function handler(req, res) {
 
   // Rate limiting
   const rateLimit = rateLimiter('auth/signup');
-  if (rateLimit(req, res)) {
+  if (await rateLimit(req, res)) {
     return;
   }
 

--- a/api/middleware/rateLimit.js
+++ b/api/middleware/rateLimit.js
@@ -1,17 +1,41 @@
 /**
  * Rate Limiting Middleware
  *
- * Simple in-memory rate limiter for serverless functions
- * Para producción, se recomienda usar Redis (Upstash) o Vercel Rate Limiting
+ * Uses Vercel KV (Redis) when available (production/preview).
+ * Falls back to in-memory Map for local development.
+ *
+ * Para configurar Vercel KV en producción:
+ *   1. vercel kv create
+ *   2. Agregar KV_REST_API_URL y KV_REST_API_TOKEN a las env vars
+ *
+ * Sin KV configurado, funciona con memoria local (válido para dev).
  */
 
 const logger = require('../utils/logger');
 
-// Store en memoria (se resetea en cada deploy en serverless)
-// Para producción: usar Redis/Upstash
-const requestStore = new Map();
+// ============================================================
+// Storage backend: Vercel KV con fallback a Map
+// ============================================================
+let kv = null;
+let memoryStore = null;
+let storageType = 'memory';
 
+try {
+  const vercelKv = require('@vercel/kv');
+  // Solo usar KV si hay URL configurada (evita errores sin env vars)
+  if (process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN) {
+    kv = vercelKv.kv;
+    storageType = 'kv';
+  } else {
+    memoryStore = new Map();
+  }
+} catch {
+  memoryStore = new Map();
+}
+
+// ============================================================
 // Configuración por endpoint
+// ============================================================
 const RATE_LIMITS = {
   'auth/signin': {
     windowMs: 15 * 60 * 1000, // 15 minutos
@@ -35,9 +59,12 @@ const RATE_LIMITS = {
   }
 };
 
-/**
- * Obtener IP del cliente
- */
+// ============================================================
+// Helpers
+// ============================================================
+
+const KV_PREFIX = 'ratelimit:';
+
 function getClientIp(req) {
   return (
     req.headers['x-forwarded-for']?.split(',')[0].trim() ||
@@ -48,142 +75,204 @@ function getClientIp(req) {
   );
 }
 
-/**
- * Limpiar entradas antiguas del store
- */
-function cleanupStore() {
+function buildKey(endpoint, ip) {
+  return `${KV_PREFIX}${endpoint}:${ip}`;
+}
+
+function getWindowSeconds(windowMs) {
+  return Math.ceil(windowMs / 1000);
+}
+
+// ============================================================
+// KV storage operations
+// ============================================================
+
+async function kvGet(key) {
+  return await kv.get(key);
+}
+
+async function kvSet(key, data, windowMs) {
+  await kv.set(key, data, { ex: getWindowSeconds(windowMs) });
+}
+
+async function kvIncrement(key, windowMs) {
+  // Usar incr para atomicidad, con expire en el primer set
+  const count = await kv.incr(key);
+  if (count === 1) {
+    // Primera request en esta ventana — setear TTL
+    await kv.expire(key, getWindowSeconds(windowMs));
+  }
+  return count;
+}
+
+// ============================================================
+// Memory storage operations (fallback local)
+// ============================================================
+
+function memoryGet(key) {
+  return memoryStore.get(key);
+}
+
+function memorySet(key, data) {
+  memoryStore.set(key, data);
+}
+
+function memoryIncrement(key) {
+  const data = memoryStore.get(key);
+  if (data) {
+    data.count++;
+    return data.count;
+  }
+  return 1;
+}
+
+function memoryCleanup() {
   const now = Date.now();
-  for (const [key, data] of requestStore.entries()) {
+  for (const [key, data] of memoryStore.entries()) {
     if (now > data.resetTime) {
-      requestStore.delete(key);
+      memoryStore.delete(key);
     }
   }
+}
+
+// ============================================================
+// Rate limiter middleware
+// ============================================================
+
+function setRateLimitHeaders(res, config, remaining, resetTime) {
+  res.setHeader('X-RateLimit-Limit', config.maxRequests);
+  res.setHeader('X-RateLimit-Remaining', Math.max(0, remaining));
+  res.setHeader('X-RateLimit-Reset', new Date(resetTime).toISOString());
+}
+
+function sendRateLimitResponse(res, config, retryAfter) {
+  res.setHeader('Retry-After', retryAfter);
+  res.status(429).json({
+    error: config.message,
+    retryAfter: retryAfter,
+    limit: config.maxRequests
+  });
 }
 
 /**
  * Rate limiter middleware
  *
  * @param {string} endpoint - Nombre del endpoint (ej: 'auth/signin')
- * @returns {Function} Middleware function
+ * @returns {Function} Middleware function (async)
  */
 function rateLimiter(endpoint = 'default') {
-  return function(req, res) {
+  return async function(req, res) {
     const config = RATE_LIMITS[endpoint] || RATE_LIMITS.default;
     const ip = getClientIp(req);
-    const key = `${endpoint}:${ip}`;
+    const key = buildKey(endpoint, ip);
     const now = Date.now();
 
-    // Limpiar store periódicamente (cada 100 requests)
-    if (Math.random() < 0.01) {
-      cleanupStore();
-    }
+    if (kv) {
+      // ---- Vercel KV backend ----
+      const count = await kvIncrement(key, config.windowMs);
+      const remaining = config.maxRequests - count;
 
-    // Obtener o crear entrada en el store
-    let requestData = requestStore.get(key);
+      setRateLimitHeaders(res, config, remaining, now + config.windowMs);
 
-    if (!requestData || now > requestData.resetTime) {
-      // Primera request o ventana expirada
-      requestData = {
-        count: 1,
-        resetTime: now + config.windowMs,
-        firstRequestTime: now
-      };
-      requestStore.set(key, requestData);
-
-      // Headers informativos
-      res.setHeader('X-RateLimit-Limit', config.maxRequests);
-      res.setHeader('X-RateLimit-Remaining', config.maxRequests - 1);
-      res.setHeader('X-RateLimit-Reset', new Date(requestData.resetTime).toISOString());
+      if (count > config.maxRequests) {
+        logger.security('rate_limit_exceeded', {
+          endpoint, ip, count, limit: config.maxRequests, storage: 'kv'
+        });
+        sendRateLimitResponse(res, config, getWindowSeconds(config.windowMs));
+        return true; // Bloqueado
+      }
 
       return false; // No bloqueado
+
+    } else {
+      // ---- Memory backend (fallback local) ----
+      // Cleanup periódico
+      if (Math.random() < 0.01) {
+        memoryCleanup();
+      }
+
+      let data = memoryGet(key);
+
+      if (!data || now > data.resetTime) {
+        data = {
+          count: 1,
+          resetTime: now + config.windowMs,
+          firstRequestTime: now
+        };
+        memorySet(key, data);
+
+        setRateLimitHeaders(res, config, config.maxRequests - 1, data.resetTime);
+        return false;
+      }
+
+      data.count++;
+      const remaining = config.maxRequests - data.count;
+      setRateLimitHeaders(res, config, remaining, data.resetTime);
+
+      if (data.count > config.maxRequests) {
+        const retryAfter = Math.ceil((data.resetTime - now) / 1000);
+        logger.security('rate_limit_exceeded', {
+          endpoint, ip, count: data.count, limit: config.maxRequests, storage: 'memory'
+        });
+        sendRateLimitResponse(res, config, retryAfter);
+        return true;
+      }
+
+      return false;
     }
-
-    // Incrementar contador
-    requestData.count++;
-
-    // Headers informativos
-    const remaining = Math.max(0, config.maxRequests - requestData.count);
-    res.setHeader('X-RateLimit-Limit', config.maxRequests);
-    res.setHeader('X-RateLimit-Remaining', remaining);
-    res.setHeader('X-RateLimit-Reset', new Date(requestData.resetTime).toISOString());
-
-    // Verificar si excede el límite
-    if (requestData.count > config.maxRequests) {
-      const retryAfter = Math.ceil((requestData.resetTime - now) / 1000);
-      res.setHeader('Retry-After', retryAfter);
-
-      // Log de seguridad
-      logger.security('rate_limit_exceeded', {
-        endpoint,
-        ip,
-        count: requestData.count,
-        limit: config.maxRequests
-      });
-
-      res.status(429).json({
-        error: config.message,
-        retryAfter: retryAfter,
-        limit: config.maxRequests
-      });
-
-      return true; // Bloqueado
-    }
-
-    return false; // No bloqueado
   };
 }
 
-/**
- * Helper para verificar si una IP está en lista negra
- * (Para implementar en el futuro con una DB)
- */
+// ============================================================
+// Blacklist
+// ============================================================
+
 function isBlacklisted(ip) {
-  // TODO: Implementar verificación contra base de datos
   const BLACKLISTED_IPS = process.env.BLACKLISTED_IPS?.split(',') || [];
   return BLACKLISTED_IPS.includes(ip);
 }
 
-/**
- * Middleware de lista negra
- */
 function blacklistMiddleware(req, res) {
   const ip = getClientIp(req);
-
   if (isBlacklisted(ip)) {
     logger.security('blacklisted_ip_attempt', { ip });
-    res.status(403).json({
-      error: 'Acceso denegado'
-    });
-    return true; // Bloqueado
+    res.status(403).json({ error: 'Acceso denegado' });
+    return true;
+  }
+  return false;
+}
+
+// ============================================================
+// Utils
+// ============================================================
+
+async function resetLimit(endpoint, ip) {
+  const key = buildKey(endpoint, ip);
+  if (kv) {
+    await kv.del(key);
+  } else {
+    memoryStore.delete(key);
+  }
+}
+
+function getStats() {
+  if (kv) {
+    return { storage: 'kv', note: 'Stats no disponibles en KV (distribuido)' };
   }
 
-  return false; // No bloqueado
-}
-
-/**
- * Resetear límite para una IP específica (útil para testing)
- */
-function resetLimit(endpoint, ip) {
-  const key = `${endpoint}:${ip}`;
-  requestStore.delete(key);
-}
-
-/**
- * Obtener estadísticas de rate limiting
- */
-function getStats() {
   const stats = {
-    totalKeys: requestStore.size,
+    storage: 'memory',
+    totalKeys: memoryStore.size,
     endpoints: {}
   };
 
-  for (const [key, data] of requestStore.entries()) {
-    const [endpoint] = key.split(':');
-    if (!stats.endpoints[endpoint]) {
-      stats.endpoints[endpoint] = { count: 0, requests: 0 };
+  for (const [key, data] of memoryStore.entries()) {
+    const ep = key.replace(KV_PREFIX, '').split(':')[0];
+    if (!stats.endpoints[ep]) {
+      stats.endpoints[ep] = { count: 0, requests: 0 };
     }
-    stats.endpoints[endpoint].count++;
-    stats.endpoints[endpoint].requests += data.count;
+    stats.endpoints[ep].count++;
+    stats.endpoints[ep].requests += data.count;
   }
 
   return stats;

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@supabase/supabase-js": "^2.105.1",
     "@tailwindcss/vite": "^4.2.2",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/kv": "^3.0.0",
     "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.5.0
         version: 1.6.1(react@19.2.5)
+      '@vercel/kv':
+        specifier: ^3.0.0
+        version: 3.0.0
       bcryptjs:
         specifier: ^3.0.2
         version: 3.0.3
@@ -1997,6 +2000,9 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
+  '@upstash/redis@1.38.0':
+    resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
+
   '@vercel/analytics@1.6.1':
     resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
     peerDependencies:
@@ -2022,6 +2028,11 @@ packages:
         optional: true
       vue-router:
         optional: true
+
+  '@vercel/kv@3.0.0':
+    resolution: {integrity: sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==}
+    engines: {node: '>=14.6'}
+    deprecated: 'Vercel KV is deprecated. If you had an existing KV store, it should have moved to Upstash Redis which you will see under Vercel Integrations. For new projects, install a Redis integration from Vercel Marketplace: https://vercel.com/marketplace?category=storage&search=redis'
 
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
@@ -3013,6 +3024,9 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -4975,9 +4989,17 @@ snapshots:
     dependencies:
       '@types/node': 25.6.0
 
+  '@upstash/redis@1.38.0':
+    dependencies:
+      uncrypto: 0.1.3
+
   '@vercel/analytics@1.6.1(react@19.2.5)':
     optionalDependencies:
       react: 19.2.5
+
+  '@vercel/kv@3.0.0':
+    dependencies:
+      '@upstash/redis': 1.38.0
 
   '@vitejs/plugin-react@5.2.0(vite@8.0.10(@types/node@25.6.0)(esbuild@0.25.0)(jiti@2.6.1))':
     dependencies:
@@ -5973,6 +5995,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  uncrypto@0.1.3: {}
 
   undici-types@7.18.2: {}
 


### PR DESCRIPTION
## Summary
Reemplaza el rate limiter basado en `Map` en memoria por Vercel KV (Redis). En serverless, el Map se resetea en cada cold start y no comparte estado entre instancias, haciendo el rate limiting efectivamente inoperante.

## Changes
| File | Change |
|------|--------|
| `api/middleware/rateLimit.js` | Rewrite: usa Vercel KV (Redis) cuando existe `KV_REST_API_URL`, fallback a Map en local |
| `api/auth/signin.js` | `await rateLimit(req, res)` (ahora async) |
| `api/auth/signup.js` | `await rateLimit(req, res)` (ahora async) |
| `api/auth/reset-password.js` | `await rateLimit(req, res)` (ahora async) |
| `package.json` | + `@vercel/kv` |

## Design
- KV usa `INCR` + `EXPIRE` para atomicidad y TTL automatico
- Fallback a Map cuando no hay env vars (dev local)
- Mismas configuraciones: 5 intentos/15min login, 3 intentos/hora registro, 30 req/min default
- Headers `X-RateLimit-*` y `Retry-After` preservados

## Para activar en produccion
```bash
vercel kv create
# Las env vars KV_REST_API_URL y KV_REST_API_TOKEN
# se agregan automaticamente al proyecto Vercel
```

## Test Plan
- [x] 62 tests pasan (0 regresiones)
- [x] Build exitoso
- [x] Module syntax validado (`node -c`)
- [x] Fallback a memory funciona sin env vars KV