### PR TITLE
fix(auth): unify password validation using middleware

### DIFF
--- a/api/auth/reset-password.js
+++ b/api/auth/reset-password.js
@@ -5,6 +5,7 @@ const logger = require('../utils/logger');
 const { rateLimiter, blacklistMiddleware } = require('../middleware/rateLimit');
 const { corsMiddleware } = require('../middleware/cors');
 const { sendEmail, getPasswordResetEmail } = require('../services/emailService');
+const { validatePassword } = require('../middleware/validation');
 
 const supabase = createClient(
   process.env.VITE_SUPABASE_URL,
@@ -166,8 +167,9 @@ async function handleResetPassword(req, res) {
       return res.status(400).json({ error: 'Token y nueva contraseña son requeridos' });
     }
 
-    if (newPassword.length < 6) {
-      return res.status(400).json({ error: 'La contraseña debe tener al menos 6 caracteres' });
+    const passwordValidation = validatePassword(newPassword);
+    if (!passwordValidation.valid) {
+      return res.status(400).json({ error: passwordValidation.error });
     }
 
     // Verificar token

--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -4,6 +4,7 @@ const { createClient } = require('@supabase/supabase-js');
 const logger = require('../utils/logger');
 const { rateLimiter, blacklistMiddleware } = require('../middleware/rateLimit');
 const { corsMiddleware } = require('../middleware/cors');
+const { validatePassword } = require('../middleware/validation');
 
 const supabase = createClient(
   process.env.VITE_SUPABASE_URL,
@@ -71,10 +72,11 @@ module.exports = async function handler(req, res) {
       });
     }
 
-    // Validar longitud de contraseña
-    if (password.length < 8) {
+    // Validar contraseña
+    const passwordValidation = validatePassword(password);
+    if (!passwordValidation.valid) {
       return res.status(400).json({
-        error: 'La contraseña debe tener al menos 8 caracteres'
+        error: passwordValidation.error
       });
     }
 


### PR DESCRIPTION
## Summary
Unifica la validacion de password entre endpoints. `signup` pedia 8+ chars, `reset-password` pedia solo 6+. Ahora ambos usan `validatePassword()` del middleware con la misma politica.

## Changes
| File | Change |
|------|--------|
| `api/auth/signup.js` | Reemplaza inline `password.length < 8` por `validatePassword(password)` |
| `api/auth/reset-password.js` | Reemplaza inline `newPassword.length < 6` por `validatePassword(newPassword)` |

## Password policy (via middleware)
- Minimo 8 caracteres
- Al menos 1 mayuscula
- Al menos 1 minuscula
- Al menos 1 numero
- Maximo 128 caracteres
- Bloqueo de passwords debiles (password, 12345678, etc.)

## Test Plan
- [x] 62 tests pasan
- [x] Build exitoso
- [x] node -c de ambos archivos sin SyntaxError