### PR TITLE
fix(api): activate Resend provider for transactional emails

### DIFF
--- a/api/services/emailService.js
+++ b/api/services/emailService.js
@@ -2,12 +2,11 @@
  * Email Service
  *
  * Servicio centralizado para envío de emails
- * Soporta múltiples proveedores: SendGrid, Resend, Nodemailer
+ * Proveedores: Resend (activo), SendGrid (código disponible), Console (dev local)
  *
- * Para activar:
- * 1. Instalar: npm install @sendgrid/mail  O  npm install resend
- * 2. Configurar env: SENDGRID_API_KEY  O  RESEND_API_KEY
- * 3. Descomentar el provider que uses
+ * Para activar Resend en producción:
+ * 1. Configurar env: RESEND_API_KEY, FROM_EMAIL, EMAIL_PROVIDER=resend
+ * 2. En Vercel: vercel env add RESEND_API_KEY
  */
 
 const logger = require('../utils/logger');
@@ -47,9 +46,8 @@ async function sendViaSendGrid(to, subject, html, text) {
 */
 
 /**
- * Resend Provider (descomentar para usar)
+ * Resend Provider
  */
-/*
 const { Resend } = require('resend');
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -68,7 +66,6 @@ async function sendViaResend(to, subject, html, text) {
     return { success: false, error: error.message };
   }
 }
-*/
 
 /**
  * Console Provider (para desarrollo)
@@ -151,9 +148,7 @@ async function sendEmail(to, subject, html, text = null) {
       return sendViaConsole(to, subject, html, text);
 
     case 'resend':
-      // return await sendViaResend(to, subject, html, text);
-      logger.warn('Resend not configured, using console');
-      return sendViaConsole(to, subject, html, text);
+      return await sendViaResend(to, subject, html, text);
 
     case 'console':
     default:

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router-dom": "^7.13.2",
+    "resend": "^6.12.4",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       react-router-dom:
         specifier: ^7.13.2
         version: 7.13.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      resend:
+        specifier: ^6.12.4
+        version: 6.12.4
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0
@@ -1791,6 +1794,9 @@ packages:
     resolution: {integrity: sha512-i6NWUDi2SDikfSUeMJvJTRdwEKYSfTd+mvBO2Ja51S1YK+hnickBuDfD+RvPerIXLuyRu3GamgNPbNqgCGUg/Q==}
     engines: {node: '>= 18'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2365,6 +2371,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2749,6 +2758,9 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
@@ -2889,6 +2901,15 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resend@6.12.4:
+    resolution: {integrity: sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2952,6 +2973,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
@@ -4770,6 +4794,8 @@ snapshots:
       - rollup
       - supports-color
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@supabase/auth-js@2.105.1':
@@ -5355,6 +5381,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -5680,6 +5708,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  postal-mime@2.7.4: {}
+
   postcss-value-parser@4.2.0: {}
 
   postcss@8.5.12:
@@ -5846,6 +5876,11 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resend@6.12.4:
+    dependencies:
+      postal-mime: 2.7.4
+      standardwebhooks: 1.0.0
+
   rolldown@1.0.0-rc.17:
     dependencies:
       '@oxc-project/types': 0.127.0
@@ -5933,6 +5968,11 @@ snapshots:
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   std-env@4.0.0: {}
 


### PR DESCRIPTION
## Summary
Activa el provider Resend para envio de emails transaccionales. El codigo ya existia comentado — solo habia que instalar la dependencia y descomentarlo.

## Changes
| File | Change |
|------|--------|
| `api/services/emailService.js` | Descomentado `sendViaResend()` + activado en `sendEmail()` |
| `package.json` | + `resend` |

## Dev behavior (sin cambios)
- `EMAIL_PROVIDER` default es `console` — los emails se ven en consola y se guardan en `.temp-emails/`
- Perfecto para desarrollo local sin configurar nada

## Para activar en produccion
Agregar estas env vars en Vercel:
```bash
EMAIL_PROVIDER=resend
RESEND_API_KEY=<tu-api-key>
FROM_EMAIL=noreply@tappmesa.com
```

## Test Plan
- [x] 62 tests pasan (0 regresiones)
- [x] Build exitoso
- [x] Syntax validado
- [x] Console provider preservado como fallback default