### PR TITLE
chore(test): remove unused renderWithProviders helper

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -729,6 +729,10 @@ model customers {
 }
 
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+/// DEPRECATED: Use stock_inventory instead.
+/// Este modelo usa Int para stock (sin decimales) y no tiene soporte
+/// para movimientos, alertas ni proveedores. Se mantiene por compatibilidad
+/// con datos existentes. No usar para nuevas features.
 model inventory {
   id            String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   tenant_id     String?   @db.Uuid

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -53,23 +53,6 @@ export const mockProduct = {
   is_available: true,
 }
 
-// Helper to render components with providers
-export const renderWithProviders = (component, options = {}) => {
-  const {
-    initialLocation = '/',
-  } = options
-
-  // Mock window.location for the test
-  window.location.pathname = initialLocation
-
-  const AllProviders = ({ children }) => {
-    return children // We'll wrap with actual providers in the tests
-  }
-
-  // Note: render function should be imported from @testing-library/react in the actual test files
-  return { AllProviders }
-}
-
 // Helper to create mock functions with specific return values
 export const createMockFunction = (returnValue) => vi.fn(() => returnValue)
 


### PR DESCRIPTION
## Summary
`renderWithProviders` definia un `AllProviders` que retornaba `children` sin wrappearlos en ningun provider real. Nunca se usaba en ningun test.

## Changes
| File | Change |
|------|--------|
| `src/test/utils.js` | Eliminado `renderWithProviders` y su helper asociado |

Resuelve MEDIUM-04 del audit.