### PR TITLE
test: implement functional localStorage mock for tests

### DIFF
--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -12,14 +12,21 @@ window.location = {
   reload: vi.fn(),
 }
 
-// Mock localStorage
+// Mock localStorage funcional (almacena datos reales)
+const createMockStorage = () => {
+  let store = {}
+  return {
+    getItem: vi.fn((key) => store[key] ?? null),
+    setItem: vi.fn((key, value) => { store[key] = String(value) }),
+    removeItem: vi.fn((key) => { delete store[key] }),
+    clear: vi.fn(() => { store = {} }),
+    get length() { return Object.keys(store).length },
+    key: vi.fn((i) => Object.keys(store)[i] ?? null),
+    _store: store, // exposición para debugging en tests
+  }
+}
 Object.defineProperty(window, 'localStorage', {
-  value: {
-    getItem: vi.fn(),
-    setItem: vi.fn(),
-    removeItem: vi.fn(),
-    clear: vi.fn(),
-  },
+  value: createMockStorage(),
   writable: true,
 })
 


### PR DESCRIPTION
LOW-02: localStorage usaba vi.fn() que no almacenaba datos. Tests que necesitaban leer datos guardados no funcionaban.

Ahora createMockStorage() implementa getItem/setItem/removeItem/clear/ con almacenamiento real en objeto.