### PR TITLE
chore: add doc comment to SubdomainDebug debug panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,8 @@ import {
 import ProtectedRoute from './components/ProtectedRoute';
 
 // Componente para debugging
+// Debug panel visible solo en desarrollo (import.meta.env.DEV)
+// Muestra subdomain, app type y tenant para facilitar debugging multi-tenant
 const SubdomainDebug = () => {
   const { tenant, error, subdomain, appType } = useTenant();
 


### PR DESCRIPTION
LOW-03: SubdomainDebug solo visible en DEV (import.meta.env.DEV). Se agrega comentario explicando que es intencional para debugging multi-tenant.