### PR TITLE
chore: remove deprecated define block for process.env in vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -7,10 +7,6 @@ export default defineConfig({
   plugins: [react(),
     tailwindcss(),
   ],
-  define: {
-    'process.env.VITE_SUPABASE_URL': JSON.stringify(process.env.VITE_SUPABASE_URL),
-    'process.env.VITE_SUPABASE_ANON_KEY': JSON.stringify(process.env.VITE_SUPABASE_ANON_KEY),
-  },
   build: {
     rollupOptions: {
       output: {


### PR DESCRIPTION
LOW-04: Vite define reemplazaba process.env.VITE_* a build time, pero Vite ya expone import.meta.env.VITE_* y no habia usos de process.env.VITE_ en el codigo.