### PR TITLE
fix: move /contact-sales route before catch-all

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -140,9 +140,9 @@ function App() {
             {/* Ruta de inicio exacta - ahora con landing mejorada */}
             <Route path="/" element={<LandingPage />} />
 
-            {/* Ruta catch-all al final (existente) */}
-            <Route path="/*" element={<AppContent />} />
+            {/* Rutas especificas antes del catch-all */}
             <Route path="/contact-sales" element={<ContactSales/>} />
+            <Route path="/*" element={<AppContent />} />
           </Routes>
           {import.meta.env.DEV && <SubdomainDebug />}
         </TenantProvider>


### PR DESCRIPTION
LOW-05: /contact-sales estaba despues de /* (catch-all). React Router evalua en orden, /* matchea cualquier path. Movida antes del catch-all.