### PR TITLE
fix(dev): add dev server for API routes + bcrypt seed script

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -36,7 +36,7 @@ SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 
 # ─── URLs (opcional) ────────────────────────────────────────
 # FRONTEND_URL=http://localhost:5173   # Para links en emails (reset password)
-# VITE_API_BASE_URL=                   # Override para API en preview deployments
+# VITE_API_BASE_URL=http://localhost:3001  # Override para API en preview deployments
 
 # ─── Seguridad (opcional) ──────────────────────────────────
 # BLACKLISTED_IPS=1.2.3.4,5.6.7.8     # IPs bloqueadas

--- a/README.md
+++ b/README.md
@@ -167,39 +167,48 @@ Ver `DESARROLLO-LOCAL-SUBDOMINIOS.md` para configuración detallada.
 
 > ⚠️ **SOLO PARA DESARROLLO** - Cambiar en producción
 
+### Seed de datos
+
+Para crear los usuarios de prueba en la base de datos:
+
+```bash
+# Asegurate de tener VITE_SUPABASE_URL y SUPABASE_SERVICE_ROLE_KEY en .env.local
+pnpm seed
+```
+
 ### Super Admin (Acceso Global)
 ```
-Email: superadmin@tappmesa.dev
-Password: TappM3sa$2025!Super
+Email: admin@tappmesa.com
+Password: admin123
 Acceso: http://localhost:5173/admin
+```
+
+### Tenant Admin - Café Central
+```
+Email: cafe-central@cafe-central.com
+Password: admin123
+Acceso: http://cafe-central-tappmesa.localhost:5173/admin
 ```
 
 ### Tenant Admin - Tetería Luna
 ```
-Email: admin@teteria-luna.dev
-Password: T3t3r1aLun4#2025
+Email: teteria-luna@teteria-luna.com
+Password: admin123
 Acceso: http://teteria-luna-tappmesa.localhost:5173/admin
 ```
 
-### Tenant Admin - Coffee Central
+### Tenant Admin - Bistro Sunrise
 ```
-Email: admin@coffee-central.dev
-Password: C0ff33C3ntr@l!25
-Acceso: http://coffee-central-tappmesa.localhost:5173/admin
-```
-
-### Staff - Mesero
-```
-Email: mesero@teteria-luna.dev
-Password: M3s3r0T3t3r14!
-Rol: waiter
+Email: bistro-sunrise@bistro-sunrise.com
+Password: admin123
+Acceso: http://bistro-sunrise-tappmesa.localhost:5173/admin
 ```
 
-### Staff - Cocina
+### Tenant Admin - Coffee & Co
 ```
-Email: cocina@teteria-luna.dev
-Password: C0c1n4T3t3r14!
-Rol: kitchen
+Email: coffee-co@coffee-co.com
+Password: admin123
+Acceso: http://coffee-co-tappmesa.localhost:5173/admin
 ```
 
 ## 📁 Estructura del Proyecto

--- a/README.md
+++ b/README.md
@@ -103,8 +103,20 @@ npx prisma db push
 ```
 
 5. **Iniciar servidor de desarrollo**
+
+Las API routes (serverless functions de Vercel) necesitan un servidor aparte:
+
 ```bash
+# Terminal 1: API routes (puerto :3001)
+node dev-server.js
+
+# Terminal 2: Frontend (puerto :5173)
 pnpm dev
+```
+
+O en una sola terminal:
+```bash
+pnpm dev:all
 ```
 
 Acceder a: `http://localhost:5173`

--- a/dev-server.js
+++ b/dev-server.js
@@ -1,0 +1,109 @@
+/**
+ * Dev server for API routes
+ *
+ * Corre las serverless functions de Vercel localmente durante desarrollo.
+ * Se necesita para que /api/auth/* funcione en localhost:5173.
+ *
+ * Uso:
+ *   node dev-server.js
+ *   # En otra terminal: pnpm dev
+ *
+ * Luego Vite proxy-redirige /api/* a este servidor en :3001.
+ */
+
+const http = require('http')
+const url = require('url')
+const path = require('path')
+
+// Cargar .env.local para que las API routes tengan acceso a las credenciales
+try {
+  require('dotenv').config({ path: path.join(__dirname, '.env.local') })
+} catch {
+  // dotenv puede no estar disponible en produccion
+}
+
+const PORT = 3001
+
+// Map de rutas a handlers
+const routes = {
+  'POST:/api/auth/signin': require('./api/auth/signin'),
+  'POST:/api/auth/signup': require('./api/auth/signup'),
+  'POST:/api/auth/signout': require('./api/auth/signout'),
+  'GET:/api/auth/session': require('./api/auth/session'),
+  'POST:/api/auth/reset-password': require('./api/auth/reset-password'),
+}
+
+const server = http.createServer((req, res) => {
+  const parsedUrl = url.parse(req.url, true)
+  const pathname = parsedUrl.pathname
+  const method = req.method.toUpperCase()
+  const routeKey = `${method}:${pathname}`
+
+  // CORS headers
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+
+  if (method === 'OPTIONS') {
+    res.writeHead(204)
+    res.end()
+    return
+  }
+
+  const handler = routes[routeKey]
+
+  if (!handler) {
+    res.writeHead(404, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ error: `Route not found: ${method} ${pathname}` }))
+    return
+  }
+
+  // Parsear body
+  let body = ''
+  req.on('data', chunk => { body += chunk })
+  req.on('end', async () => {
+    try {
+      if (body) {
+        req.body = JSON.parse(body)
+      } else {
+        req.body = {}
+      }
+    } catch {
+      req.body = {}
+    }
+
+    // Armar objeto res con los metodos que las API routes esperan
+    const apiRes = {
+      status(code) {
+        res.statusCode = code
+        return this
+      },
+      json(data) {
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify(data))
+      },
+      setHeader: (name, value) => res.setHeader(name, value),
+      getHeader: (name) => res.getHeader(name),
+      end: (data) => res.end(data),
+    }
+
+    try {
+      await handler(req, apiRes)
+    } catch (error) {
+      console.error(`[dev-server] Error in ${routeKey}:`, error)
+      if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'Internal server error' }))
+      }
+    }
+  })
+})
+
+server.listen(PORT, () => {
+  console.log(`
+🚀 Dev API server running on http://localhost:${PORT}
+   Routes: POST /api/auth/signin, signup, signout, reset-password
+           GET  /api/auth/session
+   Proxied by Vite on http://localhost:5173/api/*
+`)
+})

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist', 'src/generated']),
+  globalIgnores(['dist', 'src/generated', 'dev-server.js']),
   {
     files: ['**/*.{js,jsx}'],
     ignores: ['src/generated/**'],

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
   },
   "scripts": {
     "dev": "vite",
+    "dev:api": "node dev-server.js",
+    "dev:all": "node dev-server.js & vite",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dev": "vite",
     "dev:api": "node dev-server.js",
     "dev:all": "node dev-server.js & vite",
+    "seed": "node scripts/seed-test-users.js",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/scripts/seed-test-users.js
+++ b/scripts/seed-test-users.js
@@ -210,24 +210,22 @@ async function seed() {
 
       const passwordHash = await bcrypt.hash(user.password, SALT_ROUNDS);
 
-      const { error: insertError } = await supabase.from('admin_users').insert({
-        email: user.email,
-        password_hash: passwordHash,
-        full_name: user.fullName,
-        role: user.role,
-        tenant_id: tenant?.id || null,
-        is_active: true,
-      });
+      // Upsert: si el email ya existe, actualiza password_hash y datos
+      const { error: upsertError } = await supabase
+        .from('admin_users')
+        .upsert({
+          email: user.email,
+          password_hash: passwordHash,
+          full_name: user.fullName,
+          role: user.role,
+          tenant_id: tenant?.id || null,
+          is_active: true,
+        }, { onConflict: 'email' });
 
-      if (insertError) {
-        if (insertError.code === '23505') {
-          console.log(`  ⚠️  Ya existe: ${user.email}`);
-        } else {
-          throw insertError;
-        }
-      } else {
-        console.log(`  ✅ Usuario: ${user.email} (${user.role})`);
+      if (upsertError) {
+        throw upsertError;
       }
+      console.log(`  ✅ Usuario: ${user.email} (${user.role})`);
     } catch (err) {
       console.error(`  ❌ Error con ${user.email}:`, err.message);
     }

--- a/scripts/seed-test-users.js
+++ b/scripts/seed-test-users.js
@@ -81,11 +81,34 @@ const testUsers = [
 ];
 
 async function createTenant(data) {
-  const slug = data.name.toLowerCase()
+  const baseSlug = data.name.toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/(^-|-$)/g, '');
 
+  // Verificar si ya existe un tenant con este nombre
+  const { data: existing } = await supabase
+    .from('tenants')
+    .select('id, name, slug')
+    .eq('name', data.name)
+    .maybeSingle();
+
+  if (existing) {
+    console.log(`  ⚠️  Tenant ya existe: ${existing.name} (slug: ${existing.slug})`);
+    return existing;
+  }
+
+  // Slug único: agregar sufijo si el slug ya existe
+  let slug = baseSlug;
+  const { count: slugCount } = await supabase
+    .from('tenants')
+    .select('id', { count: 'exact', head: true })
+    .eq('slug', slug);
+  if (slugCount > 0) {
+    slug = `${baseSlug}-${Date.now().toString(36)}`;
+  }
+
   const subdomain = `${slug}-${Math.random().toString(36).substr(2, 6)}`;
+  const uniqueCode = slug.toUpperCase().replace(/-/g, '').slice(0, 8);
 
   const { data: tenant, error } = await supabase
     .from('tenants')
@@ -117,7 +140,7 @@ async function createTenant(data) {
     tenant_id: tenant.id,
     number: String(i + 1),
     capacity: 4,
-    unique_code: `${slug.toUpperCase().replace(/-/g, '')}${String(i + 1).padStart(2, '0')}`,
+    unique_code: `${uniqueCode}${String(i + 1).padStart(2, '0')}`,
     status: 'available',
     is_active: true,
   }));

--- a/scripts/seed-test-users.js
+++ b/scripts/seed-test-users.js
@@ -1,36 +1,30 @@
 // Script para crear usuarios de prueba en Supabase
-import { createClient } from '@supabase/supabase-js'
+// Uso: node scripts/seed-test-users.js
+// Requiere: VITE_SUPABASE_URL y SUPABASE_SERVICE_ROLE_KEY en .env.local
 
-// Configuración de Supabase (usar variables de entorno en producción)
-const supabaseUrl = process.env.VITE_SUPABASE_URL || 'YOUR_SUPABASE_URL'
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || 'YOUR_SERVICE_ROLE_KEY'
+const bcrypt = require('bcryptjs');
+const { createClient } = require('@supabase/supabase-js');
+require('dotenv').config({ path: require('path').join(__dirname, '..', '.env.local') });
 
-if (!supabaseUrl.startsWith('https://') || !supabaseServiceKey.startsWith('eyJ')) {
-  console.error('ERROR: Por favor configura las variables de entorno VITE_SUPABASE_URL y SUPABASE_SERVICE_ROLE_KEY')
-  console.log('Ejemplo:')
-  console.log('VITE_SUPABASE_URL=https://tu-proyecto.supabase.co')
-  console.log('SUPABASE_SERVICE_ROLE_KEY=eyJ...')
-  process.exit(1)
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseServiceKey) {
+  console.error('ERROR: Configura VITE_SUPABASE_URL y SUPABASE_SERVICE_ROLE_KEY en .env.local');
+  process.exit(1);
 }
 
-// Cliente de Supabase con permisos de administrador
-const supabase = createClient(supabaseUrl, supabaseServiceKey)
+const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
-// Función para hashear contraseñas (misma implementación que en supabase.js)
-function hashPassword(password) {
-  // IMPORTANTE: Esta es una implementación temporal para desarrollo
-  // En producción deberías usar bcrypt en el servidor
-  return btoa(password)
-}
+const SALT_ROUNDS = 12;
 
-// Datos de los usuarios de prueba
 const testUsers = [
   {
     email: 'admin@tappmesa.com',
     password: 'admin123',
     fullName: 'Super Administrador',
     role: 'super_admin',
-    tenantData: null // Super admin no tiene tenant específico
+    tenantData: null,
   },
   {
     email: 'cafe-central@cafe-central.com',
@@ -39,11 +33,11 @@ const testUsers = [
     role: 'tenant_admin',
     tenantData: {
       name: 'Café Central',
-      business_type: 'cafe',
+      businessType: 'cafe',
       phone: '+56912345001',
       address: 'Av. Providencia 1234, Santiago',
-      numberOfTables: 8
-    }
+      numberOfTables: 8,
+    },
   },
   {
     email: 'teteria-luna@teteria-luna.com',
@@ -52,11 +46,11 @@ const testUsers = [
     role: 'tenant_admin',
     tenantData: {
       name: 'Tetería Luna',
-      business_type: 'cafe',
+      businessType: 'cafe',
       phone: '+56912345002',
       address: 'Av. Las Condes 5678, Las Condes',
-      numberOfTables: 6
-    }
+      numberOfTables: 6,
+    },
   },
   {
     email: 'bistro-sunrise@bistro-sunrise.com',
@@ -65,11 +59,11 @@ const testUsers = [
     role: 'tenant_admin',
     tenantData: {
       name: 'Bistro Sunrise',
-      business_type: 'restaurant',
+      businessType: 'restaurant',
       phone: '+56912345003',
       address: 'Av. Vitacura 9012, Vitacura',
-      numberOfTables: 12
-    }
+      numberOfTables: 12,
+    },
   },
   {
     email: 'coffee-co@coffee-co.com',
@@ -78,210 +72,152 @@ const testUsers = [
     role: 'tenant_admin',
     tenantData: {
       name: 'Coffee & Co',
-      business_type: 'cafe',
+      businessType: 'cafe',
       phone: '+56912345004',
       address: 'Av. Ñuñoa 3456, Ñuñoa',
-      numberOfTables: 10
-    }
-  }
-]
+      numberOfTables: 10,
+    },
+  },
+];
 
-async function createTenant(tenantData) {
-  const tenantSlug = tenantData.name.toLowerCase()
+async function createTenant(data) {
+  const slug = data.name.toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)+/g, '')
+    .replace(/(^-|-$)/g, '');
 
-  const subdomain = tenantSlug + '-' + Math.random().toString(36).substr(2, 6)
+  const subdomain = `${slug}-${Math.random().toString(36).substr(2, 6)}`;
 
-  const { data: tenant, error: tenantError } = await supabase
+  const { data: tenant, error } = await supabase
     .from('tenants')
-    .insert([
-      {
-        name: tenantData.name,
-        slug: tenantSlug,
-        subdomain: subdomain,
-        business_type: tenantData.business_type,
-        phone: tenantData.phone,
-        email: tenantData.email || '',
-        address: tenantData.address,
-        description: `${tenantData.name} - Restaurante de prueba`,
-        is_active: true
-      }
-    ])
-    .select()
-    .single()
-
-  if (tenantError) throw tenantError
-
-  // Crear configuraciones del tenant
-  await supabase
-    .from('tenant_settings')
-    .insert([
-      {
-        tenant_id: tenant.id,
-        table_service_enabled: true,
-        takeaway_enabled: true,
-        delivery_enabled: false
-      }
-    ])
-
-  // Crear mesas
-  const tables = []
-  for (let i = 1; i <= tenantData.numberOfTables; i++) {
-    tables.push({
-      tenant_id: tenant.id,
-      number: i.toString(),
-      capacity: 4,
-      unique_code: `${tenant.slug}-mesa-${i}`,
-      status: 'available'
+    .insert({
+      name: data.name,
+      slug,
+      subdomain,
+      business_type: data.businessType,
+      phone: data.phone,
+      address: data.address,
+      description: `${data.name} - Restaurante de prueba`,
+      is_active: true,
     })
-  }
+    .select()
+    .single();
 
-  await supabase
-    .from('tables')
-    .insert(tables)
+  if (error) throw error;
 
-  // Crear categorías por defecto
-  const defaultCategories = [
-    { name: 'Bebidas Calientes', icon: '☕', display_order: 1 },
-    { name: 'Bebidas Frías', icon: '🥤', display_order: 2 },
-    { name: 'Comida', icon: '🍽️', display_order: 3 },
-    { name: 'Postres', icon: '🍰', display_order: 4 }
-  ]
-
-  const categoriesWithTenant = defaultCategories.map(cat => ({
-    ...cat,
+  // Settings
+  await supabase.from('tenant_settings').insert({
     tenant_id: tenant.id,
-    slug: cat.name.toLowerCase().replace(/\s+/g, '-'),
-    is_active: true
-  }))
+    table_service_enabled: true,
+    takeaway_enabled: true,
+    delivery_enabled: false,
+  });
 
+  // Mesas
+  const tables = Array.from({ length: data.numberOfTables }, (_, i) => ({
+    tenant_id: tenant.id,
+    number: String(i + 1),
+    capacity: 4,
+    unique_code: `${slug.toUpperCase().replace(/-/g, '')}${String(i + 1).padStart(2, '0')}`,
+    status: 'available',
+    is_active: true,
+  }));
+
+  await supabase.from('tables').insert(tables);
+
+  // Categorías
   const { data: categories } = await supabase
     .from('categories')
-    .insert(categoriesWithTenant)
-    .select()
-
-  // Crear productos de ejemplo
-  const sampleProducts = [
-    { name: 'Café Americano', price: 2500, category_name: 'Bebidas Calientes', description: 'Café negro clásico' },
-    { name: 'Cappuccino', price: 3200, category_name: 'Bebidas Calientes', description: 'Café con leche espumosa' },
-    { name: 'Latte', price: 3500, category_name: 'Bebidas Calientes', description: 'Café con leche cremosa' },
-    { name: 'Jugo Natural', price: 2800, category_name: 'Bebidas Frías', description: 'Jugo de frutas frescas' },
-    { name: 'Smoothie', price: 4200, category_name: 'Bebidas Frías', description: 'Batido de frutas' },
-    { name: 'Sandwich Completo', price: 5500, category_name: 'Comida', description: 'Sandwich con palta, tomate y mayo' },
-    { name: 'Ensalada César', price: 6800, category_name: 'Comida', description: 'Ensalada con pollo y aderezo césar' },
-    { name: 'Torta de Chocolate', price: 3800, category_name: 'Postres', description: 'Deliciosa torta casera' },
-    { name: 'Cheesecake', price: 4200, category_name: 'Postres', description: 'Tarta de queso con frutos rojos' }
-  ]
-
-  for (const product of sampleProducts) {
-    const category = categories.find(cat => cat.name === product.category_name)
-    if (category) {
-      await supabase
-        .from('products')
-        .insert([
-          {
-            tenant_id: tenant.id,
-            category_id: category.id,
-            name: product.name,
-            description: product.description,
-            price: product.price,
-            slug: product.name.toLowerCase().replace(/\s+/g, '-'),
-            is_available: true,
-            display_order: 1
-          }
-        ])
-    }
-  }
-
-  console.log(`✅ Tenant creado: ${tenant.name} (${tenant.subdomain})`)
-  return tenant
-}
-
-async function createUser(userData) {
-  let tenant = null
-
-  // Crear tenant si es necesario
-  if (userData.tenantData) {
-    tenant = await createTenant(userData.tenantData)
-  }
-
-  // Crear usuario admin
-  const { error: adminError } = await supabase
-    .from('admin_users')
     .insert([
-      {
-        email: userData.email,
-        password_hash: hashPassword(userData.password),
-        full_name: userData.fullName,
-        role: userData.role,
-        tenant_id: tenant?.id || null,
-        is_active: true
-      }
+      { name: 'Bebidas Calientes', icon: '☕', slug: 'bebidas-calientes', display_order: 1, tenant_id: tenant.id, is_active: true },
+      { name: 'Bebidas Frías', icon: '🥤', slug: 'bebidas-frias', display_order: 2, tenant_id: tenant.id, is_active: true },
+      { name: 'Comida', icon: '🍽️', slug: 'comida', display_order: 3, tenant_id: tenant.id, is_active: true },
+      { name: 'Postres', icon: '🍰', slug: 'postres', display_order: 4, tenant_id: tenant.id, is_active: true },
     ])
-    .select()
-    .single()
+    .select();
 
-  if (adminError) {
-    if (adminError.code === '23505') {
-      console.log(`⚠️  Usuario ya existe: ${userData.email}`)
-      return
+  // Productos
+  const products = [
+    { name: 'Café Americano', price: 2500, category: 'Bebidas Calientes', desc: 'Café negro clásico' },
+    { name: 'Cappuccino', price: 3200, category: 'Bebidas Calientes', desc: 'Café con leche espumosa' },
+    { name: 'Latte', price: 3500, category: 'Bebidas Calientes', desc: 'Café con leche cremosa' },
+    { name: 'Jugo Natural', price: 2800, category: 'Bebidas Frías', desc: 'Jugo de frutas frescas' },
+    { name: 'Smoothie', price: 4200, category: 'Bebidas Frías', desc: 'Batido de frutas' },
+    { name: 'Sandwich Completo', price: 5500, category: 'Comida', desc: 'Sandwich con palta, tomate y mayo' },
+    { name: 'Ensalada César', price: 6800, category: 'Comida', desc: 'Ensalada con pollo y aderezo césar' },
+    { name: 'Torta de Chocolate', price: 3800, category: 'Postres', desc: 'Deliciosa torta casera' },
+    { name: 'Cheesecake', price: 4200, category: 'Postres', desc: 'Tarta de queso con frutos rojos' },
+  ];
+
+  for (const p of products) {
+    const cat = categories.find(c => c.name === p.category);
+    if (cat) {
+      await supabase.from('products').insert({
+        tenant_id: tenant.id,
+        category_id: cat.id,
+        name: p.name,
+        description: p.desc,
+        price: p.price,
+        slug: p.name.toLowerCase().replace(/\s+/g, '-'),
+        is_available: true,
+        display_order: 1,
+      });
     }
-    throw adminError
   }
 
-  console.log(`✅ Usuario creado: ${userData.email} (${userData.role})`)
-
-  if (tenant) {
-    console.log(`   └── Tenant: ${tenant.name}`)
-    console.log(`   └── Subdomain: ${tenant.subdomain}`)
-    console.log(`   └── Mesas: ${userData.tenantData.numberOfTables}`)
-  }
+  console.log(`  ✅ Tenant: ${tenant.name} (${slug}) — ${data.numberOfTables} mesas, ${products.length} productos`);
+  return tenant;
 }
 
-async function seedTestUsers() {
-  console.log('🌱 Iniciando creación de usuarios de prueba...\n')
+async function seed() {
+  console.log('🌱 Sembrando datos de prueba...\n');
 
-  try {
-    // Verificar conexión a Supabase
-    const { error } = await supabase.from('tenants').select('count').limit(1)
-    if (error) {
-      throw new Error('Error de conexión a Supabase: ' + error.message)
-    }
+  const { error } = await supabase.from('tenants').select('count', { count: 'exact', head: true }).limit(1);
+  if (error) {
+    console.error('❌ Error de conexión a Supabase:', error.message);
+    process.exit(1);
+  }
+  console.log('✅ Conexión a Supabase OK\n');
 
-    console.log('✅ Conexión a Supabase establecida\n')
-
-    // Crear cada usuario
-    for (const userData of testUsers) {
-      try {
-        await createUser(userData)
-      } catch (error) {
-        console.error(`❌ Error creando usuario ${userData.email}:`, error.message)
-      }
-    }
-
-    console.log('\n🎉 Proceso completado!')
-    console.log('\n📝 Credenciales de prueba creadas:')
-    console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━')
-
-    testUsers.forEach(user => {
-      console.log(`👤 ${user.fullName}`)
-      console.log(`   📧 Email: ${user.email}`)
-      console.log(`   🔑 Password: ${user.password}`)
-      console.log(`   🏷️  Role: ${user.role}`)
+  for (const user of testUsers) {
+    try {
+      let tenant = null;
       if (user.tenantData) {
-        console.log(`   🏪 Restaurante: ${user.tenantData.name}`)
+        tenant = await createTenant(user.tenantData);
       }
-      console.log('')
-    })
 
-    console.log('💡 Puedes usar estas credenciales para probar la aplicación')
+      const passwordHash = await bcrypt.hash(user.password, SALT_ROUNDS);
 
-  } catch (error) {
-    console.error('❌ Error general:', error.message)
-    process.exit(1)
+      const { error: insertError } = await supabase.from('admin_users').insert({
+        email: user.email,
+        password_hash: passwordHash,
+        full_name: user.fullName,
+        role: user.role,
+        tenant_id: tenant?.id || null,
+        is_active: true,
+      });
+
+      if (insertError) {
+        if (insertError.code === '23505') {
+          console.log(`  ⚠️  Ya existe: ${user.email}`);
+        } else {
+          throw insertError;
+        }
+      } else {
+        console.log(`  ✅ Usuario: ${user.email} (${user.role})`);
+      }
+    } catch (err) {
+      console.error(`  ❌ Error con ${user.email}:`, err.message);
+    }
   }
+
+  console.log('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log('🎉 Seed completado!\n');
+  console.log('Credenciales:');
+  testUsers.forEach(u => {
+    console.log(`  ${u.fullName}: ${u.email} / ${u.password}`);
+    if (u.tenantData) console.log(`    → ${u.tenantData.name}`);
+  });
+  console.log('');
 }
 
-// Ejecutar el script
-seedTestUsers()
+seed();

--- a/vite.config.js
+++ b/vite.config.js
@@ -88,6 +88,14 @@ export default defineConfig({
   server: {
     host: "0.0.0.0", // Permite conexiones externas
     port: 5173,
+    // Proxy para API routes (Vercel serverless functions)
+    // Requiere: node dev-server.js (corre en :3001)
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+    },
     // Permitir hosts personalizados para subdominios
     allowedHosts: [
       "tappmesa.local",


### PR DESCRIPTION
## Dev server para API routes
El dev server de Vite no puede ejecutar las serverless functions de Vercel (api/auth/*).

- Creado `dev-server.js`: mini servidor Node.js que monta las API routes en :3001
- Vite proxy: /api/* -> localhost:3001
- Scripts: `pnpm dev:api`, `pnpm dev:all`
- README: instrucciones actualizadas

## Seed script con bcrypt
El seed script existente usaba btoa() (base64) pero las API routes ahora usan bcrypt. Los passwords con base64 no matchean bcrypt.

- Seed reescrito a CJS con bcrypt.hash() y 12 rounds
- Lee .env.local via dotenv
- Crea 5 usuarios + tenants con categorias, productos y mesas
- `pnpm seed` para ejecutar